### PR TITLE
Use refresh token when API is unauthorized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMG ?= ${IMAGE_REPO}/${IMAGE_NAME}:${VERSION}
 RELEASE_PROJECT = true
 
 build:
-	docker build . -t ${IMG}
+	docker buildx build --platform linux/amd64 .  -t ${IMG}
 
 reload-to-kind: build
 	kind load docker-image ${IMG}


### PR DESCRIPTION
- implement an inflight channel to let api requets complete before exiting
- check updated tokens from disk before using the refresh token